### PR TITLE
Fix duplicate download bug

### DIFF
--- a/config.js
+++ b/config.js
@@ -47,7 +47,7 @@ function getIsDevelopment() {
 
 // Server configuration
 const SERVER_URLS = {
-    development: 'https://tmp.chph.dev',
+    development: 'https://zentransfer.io',
     production: 'https://zentransfer.io'
 };
 

--- a/main.js
+++ b/main.js
@@ -729,6 +729,7 @@ class DownloadWorkerManager {
         // Update latestDownloadedFileTime to the most recent file's created timestamp
         // from this batch. This prevents re-fetching the same files on subsequent polls
         // while downloads are still in progress.
+        const previousSyncTime = this.latestDownloadedFileTime;
         for (const file of files) {
           if (file.created) {
             if (!this.latestDownloadedFileTime || file.created > this.latestDownloadedFileTime) {
@@ -736,8 +737,13 @@ class DownloadWorkerManager {
             }
           }
         }
-        if (this.latestDownloadedFileTime) {
+        if (this.latestDownloadedFileTime && this.latestDownloadedFileTime !== previousSyncTime) {
           console.log(`Advanced sync time to: ${this.latestDownloadedFileTime}`);
+          // Persist to renderer so localStorage stays in sync with the in-memory value
+          this.sendDownloadUpdate({
+            type: 'sync-time-update',
+            syncTime: this.latestDownloadedFileTime
+          });
         }
       } else {
         console.log('No new files found');
@@ -988,6 +994,20 @@ function createWindow() {
   // Show window when ready to prevent visual flash
   mainWindow.once('ready-to-show', () => {
     mainWindow.show();
+  });
+
+  // Persist the latest sync time before the window is destroyed (covers the X button path)
+  mainWindow.on('close', () => {
+    if (downloadWorkerPool && downloadWorkerPool.latestDownloadedFileTime) {
+      try {
+        mainWindow.webContents.send('download-update', {
+          type: 'sync-time-update',
+          syncTime: downloadWorkerPool.latestDownloadedFileTime
+        });
+      } catch (e) {
+        // Window may already be partially destroyed; ignore
+      }
+    }
   });
 
   // Open DevTools in development
@@ -1258,6 +1278,15 @@ function setupIpcHandlers() {
    ipcMain.handle('app-quit', async (event) => {
      try {
        console.log('Received app quit request from renderer');
+       
+       // Persist the latest sync time to the renderer's localStorage before shutting down.
+       // This prevents re-downloading files that were already fetched in the current session.
+       if (downloadWorkerPool && downloadWorkerPool.latestDownloadedFileTime) {
+         downloadWorkerPool.sendDownloadUpdate({
+           type: 'sync-time-update',
+           syncTime: downloadWorkerPool.latestDownloadedFileTime
+         });
+       }
        
        // Cancel all active operations
        if (uploadWorkerPool) {

--- a/main.js
+++ b/main.js
@@ -725,11 +725,24 @@ class DownloadWorkerManager {
       
       if (files.length > 0) {
         console.log(`Found ${files.length} new files from server`);
-        // Don't update sync time here - it will be updated when files are successfully downloaded
+
+        // Update latestDownloadedFileTime to the most recent file's created timestamp
+        // from this batch. This prevents re-fetching the same files on subsequent polls
+        // while downloads are still in progress.
+        for (const file of files) {
+          if (file.created) {
+            if (!this.latestDownloadedFileTime || file.created > this.latestDownloadedFileTime) {
+              this.latestDownloadedFileTime = file.created;
+            }
+          }
+        }
+        if (this.latestDownloadedFileTime) {
+          console.log(`Advanced sync time to: ${this.latestDownloadedFileTime}`);
+        }
       } else {
         console.log('No new files found');
       }
-      
+
       return { files, hasMoreItems };
       
     } catch (error) {
@@ -746,8 +759,28 @@ class DownloadWorkerManager {
   }
   
   addFileToQueue(fileInfo) {
+    const fileId = fileInfo.id;
+
+    // Deduplication: skip if already in the download queue
+    if (fileId && this.downloadQueue.some(f => f.id === fileId)) {
+      console.log(`Skipping duplicate file already in queue: ${fileInfo.name} (id: ${fileId})`);
+      return;
+    }
+
+    // Deduplication: skip if already completed
+    if (fileId && this.completedFiles.some(f => f.id === fileId)) {
+      console.log(`Skipping already completed file: ${fileInfo.name} (id: ${fileId})`);
+      return;
+    }
+
+    // Deduplication: skip if currently being downloaded (active job)
+    if (fileId && Array.from(this.activeJobs.values()).some(({ job }) => job.file.id === fileId)) {
+      console.log(`Skipping file already being downloaded: ${fileInfo.name} (id: ${fileId})`);
+      return;
+    }
+
     const file = {
-      id: fileInfo.id || Date.now() + Math.random(),
+      id: fileId || Date.now() + Math.random(),
       jobId: null, // Will be assigned when download starts
       name: fileInfo.name,
       size: fileInfo.size,
@@ -762,7 +795,7 @@ class DownloadWorkerManager {
       totalBytes: fileInfo.size || 0,
       error: null
     };
-    
+
     this.downloadQueue.push(file);
     console.log(`Added file to queue: ${file.name} (queue size: ${this.downloadQueue.length})`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "electron-builder": "^24.13.3",
         "electron-reload": "^2.0.0-alpha.1",
         "glob": "^11.0.2",
-        "tailwindcss": "^3.3.5"
+        "tailwindcss": "^3.4.19"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7497,9 +7497,9 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7511,7 +7511,7 @@
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.21.6",
+        "jiti": "^1.21.7",
         "lilconfig": "^3.1.3",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
@@ -7520,7 +7520,7 @@
         "postcss": "^8.4.47",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
         "postcss-nested": "^6.2.0",
         "postcss-selector-parser": "^6.1.2",
         "resolve": "^1.22.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ZenTransfer",
-  "version": "0.1.22",
+  "version": "0.1.24",
   "description": "File transfer for professional photographers",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "electron-builder": "^24.13.3",
     "electron-reload": "^2.0.0-alpha.1",
     "glob": "^11.0.2",
-    "tailwindcss": "^3.3.5"
+    "tailwindcss": "^3.4.19"
   },
   "build": {
     "appId": "com.perceptron.zentransfer",

--- a/src/screens/download-screen.js
+++ b/src/screens/download-screen.js
@@ -108,12 +108,22 @@ export class DownloadScreen {
                         <span class="text-sm font-medium text-gray-700">Last Sync:</span>
                         <span id="lastSyncTime" class="text-sm text-gray-600">Never</span>
                     </div>
-                    <button 
-                        id="resetSyncBtn" 
-                        class="text-sm text-blue-600 hover:text-blue-800 underline"
-                    >
-                        Reset
-                    </button>
+                    <div class="flex items-center space-x-3">
+                        <button
+                            id="syncFromNowBtn"
+                            class="text-sm text-green-600 hover:text-green-800 underline"
+                            title="Only download files uploaded from this moment onwards"
+                        >
+                            Sync from now
+                        </button>
+                        <button
+                            id="resetSyncBtn"
+                            class="text-sm text-blue-600 hover:text-blue-800 underline"
+                            title="Re-download all files from the beginning"
+                        >
+                            Reset
+                        </button>
+                    </div>
                 </div>
 
                 <!-- Start Button -->
@@ -193,6 +203,7 @@ export class DownloadScreen {
         this.elements.browsePathBtn = document.getElementById('browsePathBtn');
         this.elements.startMonitorBtn = document.getElementById('startMonitorBtn');
         this.elements.lastSyncTime = document.getElementById('lastSyncTime');
+        this.elements.syncFromNowBtn = document.getElementById('syncFromNowBtn');
         this.elements.resetSyncBtn = document.getElementById('resetSyncBtn');
         
         // Monitoring mode elements
@@ -264,6 +275,13 @@ export class DownloadScreen {
         if (this.elements.startMonitorBtn) {
             this.elements.startMonitorBtn.addEventListener('click', () => {
                 this.startMonitoring();
+            });
+        }
+
+        // Sync from now button
+        if (this.elements.syncFromNowBtn) {
+            this.elements.syncFromNowBtn.addEventListener('click', () => {
+                this.syncFromNow();
             });
         }
 
@@ -485,6 +503,27 @@ export class DownloadScreen {
             const hasPath = this.queueManager.downloadPath && this.queueManager.downloadPath.trim();
             this.elements.startMonitorBtn.disabled = !hasPath;
         }
+    }
+
+    /**
+     * Set sync time to the current moment so only future uploads are downloaded
+     */
+    async syncFromNow() {
+        const nowTime = new Date().toISOString();
+        StorageManager.setLastSyncTime(nowTime);
+        this.updateLastSyncDisplay(nowTime);
+
+        if (typeof require !== 'undefined') {
+            try {
+                const { ipcRenderer } = require('electron');
+                await ipcRenderer.invoke('reset-sync-time', nowTime);
+                console.log('Sync time set to now in main process:', nowTime);
+            } catch (error) {
+                console.error('Failed to update sync time in main process:', error);
+            }
+        }
+
+        UIComponents.Notification.show('Sync time set to now — only new uploads will be downloaded', 'success');
     }
 
     /**


### PR DESCRIPTION
Set sync timestamp after sync, not after file download
Save sync timestamp on application exit
New sync from now reset timestamp option

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts download polling/sync state and queue deduplication logic, which could affect which files get downloaded and when. Risk is moderated by being scoped to the download monitor flow and adds safeguards against reprocessing.
> 
> **Overview**
> **Download monitoring now advances and persists the sync cursor earlier**: `fetchNewFilesFromServer` updates `latestDownloadedFileTime` to the newest `created` timestamp in each polled batch and immediately emits a `sync-time-update` so subsequent polls don’t re-fetch the same items while downloads are still running.
> 
> **Adds stronger duplicate protection and better state persistence**: `addFileToQueue` skips files already queued, active, or completed, and the app now sends a final `sync-time-update` on window close and on `app-quit` to keep renderer `localStorage` in sync.
> 
> **User-facing + build tweaks**: Download screen adds a *Sync from now* button that sets the sync time to the current moment, dev server URL now matches production, and Tailwind + app version are bumped (`0.1.22` → `0.1.24`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf77f01b957f5ac0078981ca843e97cb77fef091. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->